### PR TITLE
chore: add type of commit 'ci'

### DIFF
--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -7,5 +7,5 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@v4.3.0
         with:
-          regexp: "^(feat|fix|chore|upgrade|merge|release|revert)(\\(.+\\))?!?: .+"
+          regexp: "^(feat|fix|chore|upgrade|ci|merge|release|revert)(\\(.+\\))?!?: .+"
           helpMessage: "Your PR title is invalid. Please follow the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/"


### PR DESCRIPTION
## 📑 Description

`ci` used for change for ci configuration

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
